### PR TITLE
Support yum_update_count in Zabbix 3.x

### DIFF
--- a/templates/Template OS CentOS.xml
+++ b/templates/Template OS CentOS.xml
@@ -3361,7 +3361,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>yum-update-count</key>
+                    <key>yum_update_count</key>
                     <delay>3600</delay>
                     <history>7</history>
                     <trends>365</trends>

--- a/zabbix_agentd.conf.d/yum.conf
+++ b/zabbix_agentd.conf.d/yum.conf
@@ -1,0 +1,1 @@
+UserParameter=yum_update_count,cat /tmp/yum-update-pending | wc -l


### PR DESCRIPTION
This patch fixes 2 issues:
1. the key ``yum-update-count`` is reported as unsupported in Zabbix 3.2,
2. the userparam with key ``yum-update-count`` that is referenced in the template doesn't seem to be pushed from the agent.

I renamed the key to ``yum_update_count`` and added a userparameter that will make sure the result of bin/check-updates.sh is pushed to the Zabbix server.