### PR TITLE
Avoid constant Exim version change trigger

### DIFF
--- a/zabbix_agentd.conf.d/exim.conf
+++ b/zabbix_agentd.conf.d/exim.conf
@@ -1,2 +1,2 @@
-UserParameter=exim.version, exim -bV | head -1 | cut -d " " -f 3
+UserParameter=exim.version, exim -bV 2>&1 | awk '/^Exim version/{print $3}'
 UserParameter=mailqueue-exim,sudo exim -bp | awk '{print $3}' | grep -c '^[0-9A-Z]'


### PR DESCRIPTION
Looks like some exim binaries output an extra line like:

```
2024-03-12 08:31:35 cwd=/root 2 args: exim -bV
```

Which causes constant trigger of 'Exim version changed'